### PR TITLE
Deprecate github wiki in favor of new Sepia wiki at wiki.sepia.ceph.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,4 @@
-=====================================================
- Sepia -- Notes on the test lab for the Ceph project
-=====================================================
+DEPRECATED - Please visit http://wiki.sepia.ceph.com
+----------------------------------------------------
 
-This repository contains notes on managing and using the "Sepia" lab
-of test machines, used by the Ceph project.
-
-For easy to read documents, please head over to
-
-http://ceph.github.com/sepia
+This repo has been deprecated in favor of a wiki hosted in the Sepia lab.

--- a/admin/upload-doc
+++ b/admin/upload-doc
@@ -22,4 +22,4 @@ EOF
 )"
 
 git update-ref -m 'Regenerated HTML' refs/heads/gh-pages "$COMMIT"
-git push github +gh-pages
+git push origin +gh-pages

--- a/doc/index-old.rst
+++ b/doc/index-old.rst
@@ -1,0 +1,46 @@
+=====================================================
+ Sepia -- Notes on the test lab for the Ceph project
+=====================================================
+
+.. default-domain:: standard
+
+Ceph_ is a unified, distributed storage system that operates on a large
+number of hosts connected by a TCP/IP network.
+
+.. _Ceph: http://ceph.com/
+
+`Sepia` is the name we gave to our pool of test machines. It happens
+to be both a color and a `genus of cuttlefish`_. When we have
+different kinds of hardware in the `sepia` pool, we name them after
+individual species in the *sepia* genus, for example `sepia plana`_.
+
+.. _`genus of cuttlefish`: http://en.wikipedia.org/wiki/Sepia_(genus)
+.. _`sepia plana`: http://en.wikipedia.org/wiki/Sepia_plana
+
+A useful reference for such things is http://animaldiversity.org/
+
+This repository contains notes on managing and using the "Sepia" lab
+of test machines, used by the Ceph project. It is managed as a Sphinx
+document tree and stored in a Git repository, to provide a combination
+of easy editability, searchability and developer friendliness.
+
+The target audience for this documentation is administrators; people
+**managing** the sepia machines. If all you need is to access the
+machines, you probably don't need to know any of this.
+
+While the Sepia machines are not publicly accessible, we hope to share
+tools & knowledge with the greater community. If you are an
+independent developer working on Ceph or related projects -- such as
+Ceph integration to OpenStack -- do contact us and we might be able to
+give you access to the hardware resources of the `sepia` lab. Or an
+offer of employment ;)
+
+
+Contents
+========
+
+.. toctree::
+   :glob:
+
+   servers/index
+   *

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,45 +2,6 @@
  Sepia -- Notes on the test lab for the Ceph project
 =====================================================
 
-.. default-domain:: standard
+**NOTE:** This documentation has been deprecated in favor of a wiki hosted inside the Sepia lab.
 
-Ceph_ is a unified, distributed storage system that operates on a large
-number of hosts connected by a TCP/IP network.
-
-.. _Ceph: http://ceph.com/
-
-`Sepia` is the name we gave to our pool of test machines. It happens
-to be both a color and a `genus of cuttlefish`_. When we have
-different kinds of hardware in the `sepia` pool, we name them after
-individual species in the *sepia* genus, for example `sepia plana`_.
-
-.. _`genus of cuttlefish`: http://en.wikipedia.org/wiki/Sepia_(genus)
-.. _`sepia plana`: http://en.wikipedia.org/wiki/Sepia_plana
-
-A useful reference for such things is http://animaldiversity.org/
-
-This repository contains notes on managing and using the "Sepia" lab
-of test machines, used by the Ceph project. It is managed as a Sphinx
-document tree and stored in a Git repository, to provide a combination
-of easy editability, searchability and developer friendliness.
-
-The target audience for this documentation is administrators; people
-**managing** the sepia machines. If all you need is to access the
-machines, you probably don't need to know any of this.
-
-While the Sepia machines are not publicly accessible, we hope to share
-tools & knowledge with the greater community. If you are an
-independent developer working on Ceph or related projects -- such as
-Ceph integration to OpenStack -- do contact us and we might be able to
-give you access to the hardware resources of the `sepia` lab. Or an
-offer of employment ;)
-
-
-Contents
-========
-
-.. toctree::
-   :glob:
-
-   servers/index
-   *
+Please visit http://wiki.sepia.ceph.com for the latest docs.


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>